### PR TITLE
Fix autoupdate strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Traccar is an open source GPS tracking system. It supports more than 200 GPS pro
 
 * Official app website: <https://www.traccar.org/>
 * Official admin documentation: <https://www.traccar.org/documentation/>
-* Upstream app code repository: <https://github.com/traccar/traccar-web>
+* Upstream app code repository: <https://github.com/traccar/traccar>
 * YunoHost Store: <https://apps.yunohost.org/app/traccar>
 * Report a bug: <https://github.com/YunoHost-Apps/traccar_ynh/issues>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -41,7 +41,7 @@ Traccar est un système de suivi GPS open source. Il prend en charge plus de 200
 
 * Site officiel de l’app : <https://www.traccar.org/>
 * Documentation officielle de l’admin : <https://www.traccar.org/documentation/>
-* Dépôt de code officiel de l’app : <https://github.com/traccar/traccar-web>
+* Dépôt de code officiel de l’app : <https://github.com/traccar/traccar>
 * YunoHost Store: <https://apps.yunohost.org/app/traccar>
 * Signaler un bug : <https://github.com/YunoHost-Apps/traccar_ynh/issues>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -49,6 +49,7 @@ ram.runtime = "50M"
         in_subdir = false
         format = "zip"
         autoupdate.strategy = "latest_github_tag"
+        autoupdate.asset = "^traccar-other-.*\.zip$"
 
     [resources.system_user]
     allow_email = true

--- a/manifest.toml
+++ b/manifest.toml
@@ -16,7 +16,7 @@ license = "GPL-3.0-only"
 website = "https://www.traccar.org/"
 demo = "https://www.traccar.org/demo-server/"
 admindoc = "https://www.traccar.org/documentation/"
-code = "https://github.com/traccar/traccar-web"
+code = "https://github.com/traccar/traccar"
 
 [integration]
 yunohost = ">= 11.2"


### PR DESCRIPTION
In the autoupdate PRs the upstream repository is currently changed from https://github.com/traccar/traccar to https://github.com/traccar/traccar-web which makes the tests fail. E.g. https://github.com/YunoHost-Apps/traccar_ynh/pull/7/commits/d86f84b272a4e64e7a9fce054e6e30eb035e68a9 

I just fixed the upstream repository URLs in manifest and README files.